### PR TITLE
Fix for retrieving job by ID and ability to create application for a job

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ $myjob->getApplications('rated');
 // get all archived applications for this job
 $myjob->getApplications('archived');
 
+// create new application for this job
+$myjob->createApplication(array('first_name' => 'John', 'last_name' => 'Doe', 'phone' => '703-123-4567', 'email' => 'john.doe@example.com'))
+
 // get a specific application 
 $myapplication = $hiringthing->getApplication(111);
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ $myjob->getApplications('rated');
 $myjob->getApplications('archived');
 
 // create new application for this job
-$myjob->createApplication(array('first_name' => 'John', 'last_name' => 'Doe', 'phone' => '703-123-4567', 'email' => 'john.doe@example.com'))
+$myjob->createApplication(array('first_name' => 'John', 'last_name' => 'Doe', 'phone' => '703-123-4567', 'email' => 'john.doe@example.com'));
 
 // get a specific application 
 $myapplication = $hiringthing->getApplication(111);

--- a/hiringthing.inc
+++ b/hiringthing.inc
@@ -104,7 +104,7 @@ class HiringThing {
   public function getJob($id) {
     $path = "jobs/$id";
     $data = $this->requester->request($path);
-    return new HiringThingJob($this->requester, $data);
+    return new HiringThingJob($this->requester, $data[0]);
   }
 
   /**

--- a/hiringthing.inc
+++ b/hiringthing.inc
@@ -156,6 +156,24 @@ class HiringThingJob extends HiringThingObject {
 
     return $data;
   }
+  
+  /**
+   * Creates a new application for this job
+   *
+   * @param array $applicationData An associative array containing the application data
+   * you wish to create (must contain at least first name, last name, phone, and email).
+   *
+   * @returns Associative array of response (will contain success => true) if application
+   * was created successfully.
+   */
+  public function createApplication($applicationData) {
+    $path = "jobs/{$this->id}/applications";
+    $headers = array('Content-Type' => 'application/json');
+    
+    $data = $this->requester->request($path, json_encode($applicationData), 'POST', $headers);
+    
+    return $data;
+  }
 }
 
 /**


### PR DESCRIPTION
Retrieving <base>/jobs/<id> looks like it returns an array and so updated call for creating HiringThingJob to just take first element from array.  Also added a createApplication function to HiringThingJob to allow clients to easily post a new application for a job and updated README with example usage.